### PR TITLE
Fix PostCSS config for Tailwind 4

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,10 +1,10 @@
 // postcss.config.js
-import tailwindcss from 'tailwindcss';
+import tailwindcss from '@tailwindcss/postcss';
 import autoprefixer from 'autoprefixer';
 
 export default {
   plugins: [
-    tailwindcss,  // Directly reference the imported plugin function
-    autoprefixer, // Directly reference the imported plugin function
+    tailwindcss(),
+    autoprefixer(),
   ],
 };


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` instead of `tailwindcss` in PostCSS config
- invoke both PostCSS plugins directly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846378e54b88322af19d79135aa4ef8