### PR TITLE
Fix Tailwind PostCSS plugin usage

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,8 +3,5 @@ import tailwindcss from '@tailwindcss/postcss';
 import autoprefixer from 'autoprefixer';
 
 export default {
-  plugins: [
-    tailwindcss(),
-    autoprefixer(),
-  ],
+  plugins: [tailwindcss, autoprefixer()]
 };


### PR DESCRIPTION
## Summary
- fix Tailwind PostCSS plugin usage in `postcss.config.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464c44ff648322bceb002e5b640c12